### PR TITLE
Beautify and better examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Write in an expression-oriented style, scoping variables as locally as possible:
 
 ```js
 let x = do {
-  let tmp = f();
+  let tmp = f()
   tmp * tmp + 1
 };
 ```
@@ -24,9 +24,12 @@ Use conditional statements as expressions, instead of awkward nested ternaries:
 
 ```js
 let x = do {
-  if (foo()) { f() }
-  else if (bar()) { g() }
-  else { h() }
+  if (foo())
+    a()
+  else if (bar())
+    b()
+  else
+    c()
 };
 ```
 
@@ -38,10 +41,17 @@ return (
     <Home />
     {
       do {
-        if (loggedIn) {
-          <LogoutButton />
-        } else {
+        if (!loggedIn) {
           <LoginButton />
+        } else {
+          if (membershipStatus === 'basic') {
+            <UpgradeButton />
+          } else if (membershipStatus === 'premium') {
+            <PremiumBadge />
+          } else {
+            alertUserOfPaymentIssues()
+            <CheckPaymentInfoButton />
+          }
         }
       }
     }
@@ -62,7 +72,7 @@ return (
 How to avoid either parsing conflict in statement context with `do`-`while`, or dangling-else type of ambiguity:
 
 ```js
-do do f(); while (x);
+do do f(); while (x)
 ```
 
 I have several alternatives I intend to explore here.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Write in an expression-oriented style, scoping variables as locally as possible:
 ```js
 let x = do {
   let tmp = f()
-  tmp * tmp + 1
+  tmp ** 2 + 1
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ Use conditional statements as expressions, instead of awkward nested ternaries:
 
 ```js
 let x = do {
-  if (foo())
+  if (foo()) {
     a()
-  else if (bar())
+  } else if (bar()) {
     b()
-  else
+  } else {
     c()
+  }
 };
 ```
 
@@ -43,15 +44,12 @@ return (
       do {
         if (!loggedIn) {
           <LoginButton />
-        } else {
-          if (membershipStatus === 'basic') {
+        } else if (membershipStatus === 'basic') {
             <UpgradeButton />
-          } else if (membershipStatus === 'premium') {
-            <PremiumBadge />
-          } else {
-            alertUserOfPaymentIssues()
-            <CheckPaymentInfoButton />
-          }
+        } else if (membershipStatus === 'premium') {
+          <PremiumBadge />
+        } else {
+          <CheckPaymentInfoButton />
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ return (
 ## Tennant's Correspondence Principle
 
 * key refactoring principles:
-  * `do { <expr>; }` equivalent to `<expr>`
-  * `(do { <stmt> };)` equivalent to `{ <stmt> }`
+  * `do { <expr> }` equivalent to `<expr>`
+  * `(do { <stmt> })` equivalent to `{ <stmt> }`
 * this semantic transparency is demonstrated by the semantics:
   1. Return the result of evaluating _Body_.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Write in an expression-oriented style, scoping variables as locally as possible:
 ```js
 let x = do {
   let tmp = f()
-  tmp ** 2 + 1
+  tmp ** tmp + 1
 };
 ```
 


### PR DESCRIPTION
The JSX example was poor due to its misuse of `do`. `do`, in this example, was being used where a ternary is often used, so to ensure the reason to use `do` was more effectively communicated I designed a more complicated example where a ternary would be unpreferable. Semicolons were being used off and on, therefore, I removed them as to avoid confusion. Increased readability in the conditional section and removed unnecessary curly braces.