### PR TITLE
allow return, break, and continue

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,37 +114,32 @@ The restriction on declarations is particularly unfortunate. It arises from the 
 
 The ability to use `await` and `yield` is inherited from the context of the enclosing function, as it is in any other expression.
 
-#### But doesn't `yield` let you `return`?
-
-Technically, yes, with coordination from outside of the called function. But this is a fairly obscure corner of the language; I am very hesitant to reason from its example.
-
 ### `throw`
 
 Works fine. Does what you expect.
 
 ### `break`/`continue`/`return`
 
-These are not allowed to cross the boundary of the `do`. (It's an Early Error if you try.)
-
-#### Duplicate labels
+These are allowed when in an appropriate context: `return` is allowed when the `do` is within a function, `break` is allowed when within a loop or a switch case, etc. This allows you to write code like this:
 
 ```js
-label: {
-  (do {
-    label: ;
-  });
+function getUserId(blob) {
+  let obj = do {
+    try {
+      JSON.parse(blob)
+    } catch {
+      return null; // returns from the function
+    }
+  };
+  return obj?.userId;
 }
 ```
-would be disallowed. This is in contrast to
 
-```js
-label: {
-  function inner(){
-    label: ;
-  }
-}
-```
-which is legal. This is prohibited because it's confusing, and as a bonus it would leave room for relaxing the restriction on `break`/`continue` in the future.
+#### Exceptions
+
+Because of the potential for confusion, unlabeled `break` and `continue` are not allowed within the head of a loop, whether or not the loop is within another loop.
+
+`return` is allowed even within function parameter lists, as in `function f(x = do { return null; }) {}`. It is not allowed in computed property names in class bodies.
 
 ### Conflict with `do-while`
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <head><meta charset="utf-8">
-<title>do expressions</title><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"sec-intro","aoid":null,"title":"Introduction","titleHTML":"Introduction","number":"","namespace":"<no location>","location":"","referencingIds":[],"key":"Introduction"},{"type":"production","id":"prod-DoExpression","name":"DoExpression","referencingIds":["_ref_88"],"namespace":"<no location>","location":"","key":"DoExpression"},{"type":"clause","id":"sec-doexpression-runtime-semantics-evaluation","aoid":null,"title":"Runtime Semantics: Evaluation","titleHTML":"Runtime Semantics: Evaluation","number":"1.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Runtime Semantics: Evaluation"},{"type":"clause","id":"sec-doexpression-static-semantics-early-errors","aoid":null,"title":"Static Semantics: Early Errors","titleHTML":"Static Semantics: Early Errors","number":"1.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: Early Errors"},{"type":"production","id":"prod-StatementList","name":"StatementList","referencingIds":["_ref_9","_ref_12","_ref_14","_ref_15","_ref_37","_ref_38","_ref_39","_ref_40","_ref_52","_ref_54","_ref_56","_ref_63","_ref_64","_ref_65","_ref_66","_ref_70","_ref_72","_ref_73","_ref_82","_ref_83","_ref_84","_ref_85"],"namespace":"<no location>","location":"","key":"StatementList"},{"type":"production","id":"prod-StatementListItem","name":"StatementListItem","referencingIds":["_ref_10","_ref_11","_ref_13","_ref_16","_ref_53","_ref_55","_ref_71","_ref_74"],"namespace":"<no location>","location":"","key":"StatementListItem"},{"type":"production","id":"prod-Statement","name":"Statement","referencingIds":["_ref_20","_ref_21","_ref_22","_ref_23","_ref_24","_ref_25","_ref_26"],"namespace":"<no location>","location":"","key":"Statement"},{"type":"production","id":"prod-LabelledItem","name":"LabelledItem","referencingIds":["_ref_27","_ref_28","_ref_29","_ref_51","_ref_67","_ref_68","_ref_86","_ref_87"],"namespace":"<no location>","location":"","key":"LabelledItem"},{"type":"production","id":"prod-BreakableStatement","name":"BreakableStatement","referencingIds":["_ref_59","_ref_77"],"namespace":"<no location>","location":"","key":"BreakableStatement"},{"type":"production","id":"prod-Block","name":"Block","referencingIds":["_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_41","_ref_43","_ref_45","_ref_47","_ref_48","_ref_49","_ref_50"],"namespace":"<no location>","location":"","key":"Block"},{"type":"production","id":"prod-IfStatement","name":"IfStatement","referencingIds":["_ref_58","_ref_76","_ref_89"],"namespace":"<no location>","location":"","key":"IfStatement"},{"type":"production","id":"prod-WithStatement","name":"WithStatement","referencingIds":["_ref_61","_ref_79"],"namespace":"<no location>","location":"","key":"WithStatement"},{"type":"production","id":"prod-LabelledStatement","name":"LabelledStatement","referencingIds":["_ref_80"],"namespace":"<no location>","location":"","key":"LabelledStatement"},{"type":"production","id":"prod-SwitchStatement","name":"SwitchStatement","referencingIds":["_ref_92"],"namespace":"<no location>","location":"","key":"SwitchStatement"},{"type":"production","id":"prod-CaseBlock","name":"CaseBlock","referencingIds":["_ref_30","_ref_31"],"namespace":"<no location>","location":"","key":"CaseBlock"},{"type":"production","id":"prod-CaseClause","name":"CaseClause","referencingIds":["_ref_32","_ref_34","_ref_35"],"namespace":"<no location>","location":"","key":"CaseClause"},{"type":"production","id":"prod-DefaultClause","name":"DefaultClause","referencingIds":["_ref_33","_ref_36"],"namespace":"<no location>","location":"","key":"DefaultClause"},{"type":"production","id":"prod-TryStatement","name":"TryStatement","referencingIds":["_ref_62","_ref_81"],"namespace":"<no location>","location":"","key":"TryStatement"},{"type":"production","id":"prod-Catch","name":"Catch","referencingIds":["_ref_42","_ref_44","_ref_46"],"namespace":"<no location>","location":"","key":"Catch"},{"type":"clause","id":"sec-endsiniterationordeclaration","aoid":null,"title":"Static Semantics: EndsInIterationOrDeclaration","titleHTML":"Static Semantics: EndsInIterationOrDeclaration","number":"1.3","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: EndsInIterationOrDeclaration"},{"type":"production","id":"prod-BreakStatement","name":"BreakStatement","referencingIds":["_ref_19","_ref_69","_ref_91"],"namespace":"<no location>","location":"","key":"BreakStatement"},{"type":"clause","id":"sec-isempty","aoid":null,"title":"Static Semantics: IsEmpty","titleHTML":"Static Semantics: IsEmpty","number":"1.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: IsEmpty"},{"type":"clause","id":"sec-isbreak","aoid":null,"title":"Static Semantics: IsBreak","titleHTML":"Static Semantics: IsBreak","number":"1.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: IsBreak"},{"type":"clause","id":"sec-do","aoid":null,"title":"Do Expressions","titleHTML":"Do Expressions","number":"1","namespace":"<no location>","location":"","referencingIds":[],"key":"Do Expressions"},{"type":"production","id":"prod-PrimaryExpression","name":"PrimaryExpression","referencingIds":[],"namespace":"<no location>","location":"","key":"PrimaryExpression"},{"type":"production","id":"prod-ExpressionStatement","name":"ExpressionStatement","referencingIds":["_ref_17","_ref_57","_ref_75"],"namespace":"<no location>","location":"","key":"ExpressionStatement"},{"type":"production","id":"prod-ContinueStatement","name":"ContinueStatement","referencingIds":["_ref_18","_ref_60","_ref_78","_ref_90"],"namespace":"<no location>","location":"","key":"ContinueStatement"},{"type":"clause","id":"sec-ins-break-statement-static-semantics-early-errors","aoid":null,"title":"Static Semantics: Early Errors","titleHTML":"Static Semantics: Early Errors","number":"2.1.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: Early Errors"},{"type":"clause","id":"sec-ins-continue-statement-static-semantics-early-errors","aoid":null,"title":"Static Semantics: Early Errors","titleHTML":"Static Semantics: Early Errors","number":"2.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: Early Errors"},{"type":"clause","id":"sec-integration","aoid":null,"title":"Integration","titleHTML":"Integration","number":"2","namespace":"<no location>","location":"","referencingIds":[],"key":"Integration"},{"type":"clause","id":"sec-copyright-and-software-license","aoid":null,"title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A","namespace":"<no location>","location":"","referencingIds":[],"key":"Copyright & Software License"}]</script><script>"use strict";
+<title>do expressions</title><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"sec-intro","aoid":null,"title":"Introduction","titleHTML":"Introduction","number":"","namespace":"<no location>","location":"","referencingIds":[],"key":"Introduction"},{"type":"production","id":"prod-DoExpression","name":"DoExpression","referencingIds":["_ref_83"],"namespace":"<no location>","location":"","key":"DoExpression"},{"type":"clause","id":"sec-doexpression-runtime-semantics-evaluation","aoid":null,"title":"Runtime Semantics: Evaluation","titleHTML":"Runtime Semantics: Evaluation","number":"1.1","namespace":"<no location>","location":"","referencingIds":[],"key":"Runtime Semantics: Evaluation"},{"type":"clause","id":"sec-doexpression-static-semantics-early-errors","aoid":null,"title":"Static Semantics: Early Errors","titleHTML":"Static Semantics: Early Errors","number":"1.2","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: Early Errors"},{"type":"production","id":"prod-StatementList","name":"StatementList","referencingIds":["_ref_7","_ref_10","_ref_12","_ref_13","_ref_34","_ref_35","_ref_36","_ref_37","_ref_49","_ref_51","_ref_53","_ref_59","_ref_60","_ref_61","_ref_62","_ref_66","_ref_68","_ref_69","_ref_77","_ref_78","_ref_79","_ref_80"],"namespace":"<no location>","location":"","key":"StatementList"},{"type":"production","id":"prod-StatementListItem","name":"StatementListItem","referencingIds":["_ref_8","_ref_9","_ref_11","_ref_14","_ref_50","_ref_52","_ref_67","_ref_70"],"namespace":"<no location>","location":"","key":"StatementListItem"},{"type":"production","id":"prod-Statement","name":"Statement","referencingIds":["_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23"],"namespace":"<no location>","location":"","key":"Statement"},{"type":"production","id":"prod-LabelledItem","name":"LabelledItem","referencingIds":["_ref_24","_ref_25","_ref_26","_ref_48","_ref_63","_ref_64","_ref_81","_ref_82"],"namespace":"<no location>","location":"","key":"LabelledItem"},{"type":"production","id":"prod-BreakableStatement","name":"BreakableStatement","referencingIds":["_ref_56","_ref_73"],"namespace":"<no location>","location":"","key":"BreakableStatement"},{"type":"production","id":"prod-Block","name":"Block","referencingIds":["_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_38","_ref_40","_ref_42","_ref_44","_ref_45","_ref_46","_ref_47"],"namespace":"<no location>","location":"","key":"Block"},{"type":"production","id":"prod-IfStatement","name":"IfStatement","referencingIds":["_ref_55","_ref_72","_ref_84"],"namespace":"<no location>","location":"","key":"IfStatement"},{"type":"production","id":"prod-WithStatement","name":"WithStatement","referencingIds":["_ref_57","_ref_74"],"namespace":"<no location>","location":"","key":"WithStatement"},{"type":"production","id":"prod-LabelledStatement","name":"LabelledStatement","referencingIds":["_ref_75"],"namespace":"<no location>","location":"","key":"LabelledStatement"},{"type":"production","id":"prod-SwitchStatement","name":"SwitchStatement","referencingIds":[],"namespace":"<no location>","location":"","key":"SwitchStatement"},{"type":"production","id":"prod-CaseBlock","name":"CaseBlock","referencingIds":["_ref_27","_ref_28"],"namespace":"<no location>","location":"","key":"CaseBlock"},{"type":"production","id":"prod-CaseClause","name":"CaseClause","referencingIds":["_ref_29","_ref_31","_ref_32"],"namespace":"<no location>","location":"","key":"CaseClause"},{"type":"production","id":"prod-DefaultClause","name":"DefaultClause","referencingIds":["_ref_30","_ref_33"],"namespace":"<no location>","location":"","key":"DefaultClause"},{"type":"production","id":"prod-TryStatement","name":"TryStatement","referencingIds":["_ref_58","_ref_76"],"namespace":"<no location>","location":"","key":"TryStatement"},{"type":"production","id":"prod-Catch","name":"Catch","referencingIds":["_ref_39","_ref_41","_ref_43"],"namespace":"<no location>","location":"","key":"Catch"},{"type":"clause","id":"sec-endsiniterationordeclaration","aoid":null,"title":"Static Semantics: EndsInIterationOrDeclaration","titleHTML":"Static Semantics: EndsInIterationOrDeclaration","number":"1.3","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: EndsInIterationOrDeclaration"},{"type":"production","id":"prod-BreakStatement","name":"BreakStatement","referencingIds":["_ref_16","_ref_65"],"namespace":"<no location>","location":"","key":"BreakStatement"},{"type":"clause","id":"sec-isempty","aoid":null,"title":"Static Semantics: IsEmpty","titleHTML":"Static Semantics: IsEmpty","number":"1.4","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: IsEmpty"},{"type":"clause","id":"sec-isbreak","aoid":null,"title":"Static Semantics: IsBreak","titleHTML":"Static Semantics: IsBreak","number":"1.5","namespace":"<no location>","location":"","referencingIds":[],"key":"Static Semantics: IsBreak"},{"type":"clause","id":"sec-do","aoid":null,"title":"Do Expressions","titleHTML":"Do Expressions","number":"1","namespace":"<no location>","location":"","referencingIds":[],"key":"Do Expressions"},{"type":"production","id":"prod-PrimaryExpression","name":"PrimaryExpression","referencingIds":[],"namespace":"<no location>","location":"","key":"PrimaryExpression"},{"type":"production","id":"prod-ExpressionStatement","name":"ExpressionStatement","referencingIds":["_ref_15","_ref_54","_ref_71"],"namespace":"<no location>","location":"","key":"ExpressionStatement"},{"type":"clause","id":"sec-integration","aoid":null,"title":"Integration","titleHTML":"Integration","number":"2","namespace":"<no location>","location":"","referencingIds":[],"key":"Integration"},{"type":"clause","id":"sec-copyright-and-software-license","aoid":null,"title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A","namespace":"<no location>","location":"","referencingIds":[],"key":"Copyright & Software License"}]</script><script>"use strict";
 
 function Search(menu) {
   this.menu = menu;
@@ -1848,7 +1848,7 @@ li.menu-search-result-term:before {
     display: none; 
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intro" title="Introduction">Introduction</a></li><li><span class="item-toggle">◢</span><a href="#sec-do" title="Do Expressions"><span class="secnum">1</span> Do Expressions</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-doexpression-runtime-semantics-evaluation" title="Runtime Semantics: Evaluation"><span class="secnum">1.1</span> RS: Evaluation</a></li><li><span class="item-toggle-none"></span><a href="#sec-doexpression-static-semantics-early-errors" title="Static Semantics: Early Errors"><span class="secnum">1.2</span> SS: Early Errors</a></li><li><span class="item-toggle-none"></span><a href="#sec-endsiniterationordeclaration" title="Static Semantics: EndsInIterationOrDeclaration"><span class="secnum">1.3</span> SS: EndsInIterationOrDeclaration</a></li><li><span class="item-toggle-none"></span><a href="#sec-isempty" title="Static Semantics: IsEmpty"><span class="secnum">1.4</span> SS: IsEmpty</a></li><li><span class="item-toggle-none"></span><a href="#sec-isbreak" title="Static Semantics: IsBreak"><span class="secnum">1.5</span> SS: IsBreak</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-integration" title="Integration"><span class="secnum">2</span> Integration</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-ins-continue-statement-static-semantics-early-errors" title="Static Semantics: Early Errors"><span class="secnum">2.1</span> SS: Early Errors</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-ins-break-statement-static-semantics-early-errors" title="Static Semantics: Early Errors"><span class="secnum">2.1.1</span> SS: Early Errors</a></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version first">Stage 1 Draft / January 26, 2021</h1><h1 class="title">do expressions</h1>
+</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intro" title="Introduction">Introduction</a></li><li><span class="item-toggle">◢</span><a href="#sec-do" title="Do Expressions"><span class="secnum">1</span> Do Expressions</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-doexpression-runtime-semantics-evaluation" title="Runtime Semantics: Evaluation"><span class="secnum">1.1</span> RS: Evaluation</a></li><li><span class="item-toggle-none"></span><a href="#sec-doexpression-static-semantics-early-errors" title="Static Semantics: Early Errors"><span class="secnum">1.2</span> SS: Early Errors</a></li><li><span class="item-toggle-none"></span><a href="#sec-endsiniterationordeclaration" title="Static Semantics: EndsInIterationOrDeclaration"><span class="secnum">1.3</span> SS: EndsInIterationOrDeclaration</a></li><li><span class="item-toggle-none"></span><a href="#sec-isempty" title="Static Semantics: IsEmpty"><span class="secnum">1.4</span> SS: IsEmpty</a></li><li><span class="item-toggle-none"></span><a href="#sec-isbreak" title="Static Semantics: IsBreak"><span class="secnum">1.5</span> SS: IsBreak</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-integration" title="Integration"><span class="secnum">2</span> Integration</a></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version first">Stage 1 Draft / February 28, 2021</h1><h1 class="title">do expressions</h1>
 
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
@@ -1858,10 +1858,10 @@ li.menu-search-result-term:before {
 <emu-clause id="sec-do">
   <h1><span class="secnum">1</span> Do Expressions</h1>
   <h2>Syntax</h2>
-  <emu-grammar type="definition"><emu-production name="DoExpression" params="Yield, Await" id="prod-DoExpression">
-    <emu-nt params="Yield, Await"><a href="#prod-DoExpression">DoExpression</a><emu-mods><emu-params>[Yield, Await]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="2367ffe6">
+  <emu-grammar type="definition"><emu-production name="DoExpression" params="Yield, Await, Return" id="prod-DoExpression">
+    <emu-nt params="Yield, Await, Return"><a href="#prod-DoExpression">DoExpression</a><emu-mods><emu-params>[Yield, Await, Return]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="6dqpy1ik">
         <emu-t>do</emu-t>
-        <emu-nt params="?Yield, ?Await, ~Return" id="_ref_2"><a href="#prod-Block">Block</a><emu-mods><emu-params>[?Yield, ?Await, ~Return]</emu-params></emu-mods></emu-nt>
+        <emu-nt params="?Yield, ?Await, ?Return" id="_ref_2"><a href="#prod-Block">Block</a><emu-mods><emu-params>[?Yield, ?Await, ?Return]</emu-params></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
@@ -1869,7 +1869,7 @@ li.menu-search-result-term:before {
   <emu-clause id="sec-doexpression-runtime-semantics-evaluation">
     <h1><span class="secnum">1.1</span> Runtime Semantics: Evaluation</h1>
     <emu-grammar><emu-production name="DoExpression" collapsed="">
-    <emu-nt><a href="#prod-DoExpression">DoExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="288d8cb1">
+    <emu-nt><a href="#prod-DoExpression">DoExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ki2msqgz">
         <emu-t>do</emu-t>
         <emu-nt id="_ref_3"><a href="#prod-Block">Block</a></emu-nt>
     </emu-rhs>
@@ -1881,7 +1881,7 @@ li.menu-search-result-term:before {
   <emu-clause id="sec-doexpression-static-semantics-early-errors">
     <h1><span class="secnum">1.2</span> Static Semantics: Early Errors</h1>
     <emu-grammar><emu-production name="DoExpression" collapsed="">
-    <emu-nt><a href="#prod-DoExpression">DoExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="288d8cb1">
+    <emu-nt><a href="#prod-DoExpression">DoExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ki2msqgz">
         <emu-t>do</emu-t>
         <emu-nt id="_ref_5"><a href="#prod-Block">Block</a></emu-nt>
     </emu-rhs>
@@ -1889,56 +1889,50 @@ li.menu-search-result-term:before {
 </emu-grammar>
     <ul>
       <li>
-        It is a Syntax Error if ContainsUndefinedBreakTarget of <emu-nt id="_ref_6"><a href="#prod-Block">Block</a></emu-nt> with argument « » is <emu-val>true</emu-val>.
+        TODO: a syntax error for this is contained in a loop head and contains a break or continue which would break or continue the loop.
       </li>
       <li>
-        It is a Syntax Error if ContainsUndefinedContinueTarget of <emu-nt id="_ref_7"><a href="#prod-Block">Block</a></emu-nt> with arguments « » and « » is <emu-val>true</emu-val>.
-      </li>
-      <li>
-        It is a Syntax Error if EndsInIterationOrDeclaration of <emu-nt id="_ref_8"><a href="#prod-Block">Block</a></emu-nt> with arguments « » and <emu-val>true</emu-val> is <emu-val>true</emu-val>.
+        It is a Syntax Error if EndsInIterationOrDeclaration of <emu-nt id="_ref_6"><a href="#prod-Block">Block</a></emu-nt> with arguments « » and <emu-val>true</emu-val> is <emu-val>true</emu-val>.
       </li>
     </ul>
-    <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">
-      <p>The first two Syntax Errors are present for all statement lists which are not immediately contained in other statement lists, i.e. for function bodies, scripts, modules, and now do expressions.</p>
-    </div></emu-note>
   </emu-clause>
 
   <emu-clause id="sec-endsiniterationordeclaration">
     <h1><span class="secnum">1.3</span> Static Semantics: EndsInIterationOrDeclaration</h1>
     <p>With parameters <var>labelSet</var> and <var>isLast</var>.</p>
     <emu-grammar><emu-production name="StatementList" id="prod-StatementList">
-    <emu-nt><a href="#prod-StatementList">StatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="0db4597a">
-        <emu-nt id="_ref_9"><a href="#prod-StatementList">StatementList</a></emu-nt>
-        <emu-nt id="_ref_10"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt>
+    <emu-nt><a href="#prod-StatementList">StatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="dbrzeh7l">
+        <emu-nt id="_ref_7"><a href="#prod-StatementList">StatementList</a></emu-nt>
+        <emu-nt id="_ref_8"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If IsEmpty of <emu-nt id="_ref_11"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with argument « » is <emu-val>true</emu-val>, return EndsInIterationOrDeclaration of <emu-nt id="_ref_12"><a href="#prod-StatementList">StatementList</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li><li>If IsBreak of <emu-nt id="_ref_13"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with argument <var>labelSet</var> is <emu-val>true</emu-val>, return EndsInIterationOrDeclaration of <emu-nt id="_ref_14"><a href="#prod-StatementList">StatementList</a></emu-nt> with arguments <var>labelSet</var> and <emu-val>true</emu-val>.</li><li>If EndsInIterationOrDeclaration of <emu-nt id="_ref_15"><a href="#prod-StatementList">StatementList</a></emu-nt> with arguments <var>labelSet</var> and <emu-val>false</emu-val> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_16"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If IsEmpty of <emu-nt id="_ref_9"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with argument « » is <emu-val>true</emu-val>, return EndsInIterationOrDeclaration of <emu-nt id="_ref_10"><a href="#prod-StatementList">StatementList</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li><li>If IsBreak of <emu-nt id="_ref_11"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with argument <var>labelSet</var> is <emu-val>true</emu-val>, return EndsInIterationOrDeclaration of <emu-nt id="_ref_12"><a href="#prod-StatementList">StatementList</a></emu-nt> with arguments <var>labelSet</var> and <emu-val>true</emu-val>.</li><li>If EndsInIterationOrDeclaration of <emu-nt id="_ref_13"><a href="#prod-StatementList">StatementList</a></emu-nt> with arguments <var>labelSet</var> and <emu-val>false</emu-val> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_14"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="StatementListItem" id="prod-StatementListItem">
-    <emu-nt><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="d6f37721"><emu-nt><a href="https://tc39.es/ecma262/#prod-Declaration">Declaration</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="1vn3ibwe"><emu-nt><a href="https://tc39.es/ecma262/#prod-Declaration">Declaration</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="Statement" id="prod-Statement">
-    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="8b0c0df0"><emu-nt><a href="https://tc39.es/ecma262/#prod-VariableStatement">VariableStatement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwwn8atx"><emu-nt><a href="https://tc39.es/ecma262/#prod-VariableStatement">VariableStatement</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="LabelledItem" id="prod-LabelledItem">
-    <emu-nt><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fa7a943c"><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="-nqupnlb"><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="BreakableStatement" id="prod-BreakableStatement">
-    <emu-nt><a href="#prod-BreakableStatement">BreakableStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="28c5e5e3"><emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-IterationStatement">IterationStatement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-BreakableStatement">BreakableStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="kmxl4yum"><emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-IterationStatement">IterationStatement</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar>
     <emu-alg><ol><li>Return <var>isLast</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="Statement">
-    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="7338aabb"><emu-nt><a href="https://tc39.es/ecma262/#prod-EmptyStatement">EmptyStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="82c424b7"><emu-nt id="_ref_17"><a href="#prod-ExpressionStatement">ExpressionStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="1d7d329e"><emu-nt id="_ref_18"><a href="#prod-ContinueStatement">ContinueStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="ab8baff9"><emu-nt id="_ref_19"><a href="#prod-BreakStatement">BreakStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="aa6f7913"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="867b4090"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ThrowStatement">ThrowStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="21212edb"><emu-nt><a href="https://tc39.es/ecma262/#prod-DebuggerStatement">DebuggerStatement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="cziqu-45"><emu-nt><a href="https://tc39.es/ecma262/#prod-EmptyStatement">EmptyStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="gsqkt2bv"><emu-nt id="_ref_15"><a href="#prod-ExpressionStatement">ExpressionStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="hx0ynljx"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ContinueStatement">ContinueStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="q4uv-sm3"><emu-nt id="_ref_16"><a href="#prod-BreakStatement">BreakStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="qm95e4wi"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="hntake-o"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ThrowStatement">ThrowStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="iseu28qi"><emu-nt><a href="https://tc39.es/ecma262/#prod-DebuggerStatement">DebuggerStatement</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="Block" id="prod-Block">
-    <emu-nt><a href="#prod-Block">Block</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="81ba5a4a">
+    <emu-nt><a href="#prod-Block">Block</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gbpaspne">
         <emu-t>{</emu-t>
         <emu-t>}</emu-t>
     </emu-rhs>
@@ -1946,153 +1940,153 @@ li.menu-search-result-term:before {
 </emu-grammar>
     <emu-alg><ol><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="IfStatement" id="prod-IfStatement">
-    <emu-nt><a href="#prod-IfStatement">IfStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="16e86a13">
+    <emu-nt><a href="#prod-IfStatement">IfStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fuhqe2xq">
         <emu-t>if</emu-t>
         <emu-t>(</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt>
         <emu-t>)</emu-t>
-        <emu-nt id="_ref_20"><a href="#prod-Statement">Statement</a></emu-nt>
+        <emu-nt id="_ref_17"><a href="#prod-Statement">Statement</a></emu-nt>
         <emu-t>else</emu-t>
-        <emu-nt id="_ref_21"><a href="#prod-Statement">Statement</a></emu-nt>
+        <emu-nt id="_ref_18"><a href="#prod-Statement">Statement</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>Let <var>first</var> be EndsInIterationOrDeclaration of the first <emu-nt id="_ref_22"><a href="#prod-Statement">Statement</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li><li>If <var>first</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>Return EndsInIterationOrDeclaration of the second <emu-nt id="_ref_23"><a href="#prod-Statement">Statement</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Let <var>first</var> be EndsInIterationOrDeclaration of the first <emu-nt id="_ref_19"><a href="#prod-Statement">Statement</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li><li>If <var>first</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>Return EndsInIterationOrDeclaration of the second <emu-nt id="_ref_20"><a href="#prod-Statement">Statement</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="IfStatement">
-    <emu-nt><a href="#prod-IfStatement">IfStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="f6819570">
+    <emu-nt><a href="#prod-IfStatement">IfStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="9ogvciaf">
         <emu-t>if</emu-t>
         <emu-t>(</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt>
         <emu-t>)</emu-t>
-        <emu-nt id="_ref_24"><a href="#prod-Statement">Statement</a></emu-nt>
+        <emu-nt id="_ref_21"><a href="#prod-Statement">Statement</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="WithStatement" id="prod-WithStatement">
-    <emu-nt><a href="#prod-WithStatement">WithStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="23bd2456">
+    <emu-nt><a href="#prod-WithStatement">WithStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="i70kview">
         <emu-t>with</emu-t>
         <emu-t>(</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt>
         <emu-t>)</emu-t>
-        <emu-nt id="_ref_25"><a href="#prod-Statement">Statement</a></emu-nt>
+        <emu-nt id="_ref_22"><a href="#prod-Statement">Statement</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_26"><a href="#prod-Statement">Statement</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_23"><a href="#prod-Statement">Statement</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="LabelledStatement" id="prod-LabelledStatement">
-    <emu-nt><a href="#prod-LabelledStatement">LabelledStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="51b6efb5">
+    <emu-nt><a href="#prod-LabelledStatement">LabelledStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ubbvtbun">
         <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_27"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt>
+        <emu-nt id="_ref_24"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If <var>isLast</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>label</var> be the StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>.</li><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with <var>label</var> appended.</li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_28"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> with arguments <var>newLabelSet</var> and <emu-val>true</emu-val>.</li></ol></li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_29"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If <var>isLast</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>label</var> be the StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>.</li><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with <var>label</var> appended.</li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_25"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> with arguments <var>newLabelSet</var> and <emu-val>true</emu-val>.</li></ol></li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_26"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="SwitchStatement" id="prod-SwitchStatement">
-    <emu-nt><a href="#prod-SwitchStatement">SwitchStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="515acffe">
+    <emu-nt><a href="#prod-SwitchStatement">SwitchStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="uvrp_hkw">
         <emu-t>switch</emu-t>
         <emu-t>(</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt>
         <emu-t>)</emu-t>
-        <emu-nt id="_ref_30"><a href="#prod-CaseBlock">CaseBlock</a></emu-nt>
+        <emu-nt id="_ref_27"><a href="#prod-CaseBlock">CaseBlock</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_31"><a href="#prod-CaseBlock">CaseBlock</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_28"><a href="#prod-CaseBlock">CaseBlock</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="CaseBlock" id="prod-CaseBlock">
-    <emu-nt><a href="#prod-CaseBlock">CaseBlock</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="11eac196">
+    <emu-nt><a href="#prod-CaseBlock">CaseBlock</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="eerblgqb">
         <emu-t>{</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If <var>isLast</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with <emu-const>empty</emu-const> appended.</li></ol></li><li>Else,<ol><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with any occurences of <emu-const>empty</emu-const> removed.</li></ol></li><li>Let <var>clauses</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-nt id="_ref_32"><a href="#prod-CaseClause">CaseClause</a></emu-nt> items in <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt>, in source text order.</li><li>For each element <var>clause</var> of <var>clauses</var>, in reverse <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> order, do<ol><li>If IsEmpty of <var>clause</var> with argument « » is <emu-val>false</emu-val>, then<ol><li>If EndsInIterationOrDeclaration of <var>clause</var> with arguments <var>newLabelSet</var> and <var>isLast</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If IsBreak of <var>clause</var> with argument <var>newLabelSet</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>isLast</var> to <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Set <var>isLast</var> to <emu-val>false</emu-val>.</li></ol></li></ol></li></ol></li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If <var>isLast</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with <emu-const>empty</emu-const> appended.</li></ol></li><li>Else,<ol><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with any occurences of <emu-const>empty</emu-const> removed.</li></ol></li><li>Let <var>clauses</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-nt id="_ref_29"><a href="#prod-CaseClause">CaseClause</a></emu-nt> items in <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt>, in source text order.</li><li>For each element <var>clause</var> of <var>clauses</var>, in reverse <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> order, do<ol><li>If IsEmpty of <var>clause</var> with argument « » is <emu-val>false</emu-val>, then<ol><li>If EndsInIterationOrDeclaration of <var>clause</var> with arguments <var>newLabelSet</var> and <var>isLast</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If IsBreak of <var>clause</var> with argument <var>newLabelSet</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>isLast</var> to <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Set <var>isLast</var> to <emu-val>false</emu-val>.</li></ol></li></ol></li></ol></li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="CaseBlock">
-    <emu-nt><a href="#prod-CaseBlock">CaseBlock</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="503b8396">
+    <emu-nt><a href="#prod-CaseBlock">CaseBlock</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ududlhou">
         <emu-t>{</emu-t>
         <emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_33"><a href="#prod-DefaultClause">DefaultClause</a></emu-nt>
+        <emu-nt id="_ref_30"><a href="#prod-DefaultClause">DefaultClause</a></emu-nt>
         <emu-nt optional=""><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If <var>isLast</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with <emu-const>empty</emu-const> appended.</li></ol></li><li>Else,<ol><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with any occurences of <emu-const>empty</emu-const> removed.</li></ol></li><li>If the first <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt> is present, then<ol><li>Let <var>A</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-nt id="_ref_34"><a href="#prod-CaseClause">CaseClause</a></emu-nt> items in the first <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt>, in source text order.</li></ol></li><li>Else,<ol><li>Let <var>A</var> be « ».</li></ol></li><li>If the second <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt> is present, then<ol><li>Let <var>B</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-nt id="_ref_35"><a href="#prod-CaseClause">CaseClause</a></emu-nt> items in the second <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt>, in source text order.</li></ol></li><li>Else,<ol><li>Let <var>B</var> be « ».</li></ol></li><li>Let <var>clauses</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the elements of <var>A</var>, followed by <emu-nt id="_ref_36"><a href="#prod-DefaultClause">DefaultClause</a></emu-nt>, followed by the elements of <var>B</var>.</li><li>For each element <var>clause</var> of <var>clauses</var>, in reverse <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> order, do<ol><li>If IsEmpty of <var>clause</var> with argument « » is <emu-val>false</emu-val>, then<ol><li>If EndsInIterationOrDeclaration of <var>clause</var> with arguments <var>newLabelSet</var> and <var>isLast</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If IsBreak of <var>clause</var> with argument <var>newLabelSet</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>isLast</var> to <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Set <var>isLast</var> to <emu-val>false</emu-val>.</li></ol></li></ol></li></ol></li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If <var>isLast</var> is <emu-val>true</emu-val>, then<ol><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with <emu-const>empty</emu-const> appended.</li></ol></li><li>Else,<ol><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with any occurences of <emu-const>empty</emu-const> removed.</li></ol></li><li>If the first <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt> is present, then<ol><li>Let <var>A</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-nt id="_ref_31"><a href="#prod-CaseClause">CaseClause</a></emu-nt> items in the first <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt>, in source text order.</li></ol></li><li>Else,<ol><li>Let <var>A</var> be « ».</li></ol></li><li>If the second <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt> is present, then<ol><li>Let <var>B</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-nt id="_ref_32"><a href="#prod-CaseClause">CaseClause</a></emu-nt> items in the second <emu-nt><a href="https://tc39.es/ecma262/#prod-CaseClauses">CaseClauses</a></emu-nt>, in source text order.</li></ol></li><li>Else,<ol><li>Let <var>B</var> be « ».</li></ol></li><li>Let <var>clauses</var> be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose elements are the elements of <var>A</var>, followed by <emu-nt id="_ref_33"><a href="#prod-DefaultClause">DefaultClause</a></emu-nt>, followed by the elements of <var>B</var>.</li><li>For each element <var>clause</var> of <var>clauses</var>, in reverse <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> order, do<ol><li>If IsEmpty of <var>clause</var> with argument « » is <emu-val>false</emu-val>, then<ol><li>If EndsInIterationOrDeclaration of <var>clause</var> with arguments <var>newLabelSet</var> and <var>isLast</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If IsBreak of <var>clause</var> with argument <var>newLabelSet</var> is <emu-val>true</emu-val>, then<ol><li>Set <var>isLast</var> to <emu-val>true</emu-val>.</li></ol></li><li>Else,<ol><li>Set <var>isLast</var> to <emu-val>false</emu-val>.</li></ol></li></ol></li></ol></li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="CaseClause" id="prod-CaseClause">
-    <emu-nt><a href="#prod-CaseClause">CaseClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="c76d0d30">
+    <emu-nt><a href="#prod-CaseClause">CaseClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="x20nmjyd">
         <emu-t>case</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt>
         <emu-t>:</emu-t>
-        <emu-nt optional="" id="_ref_37"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_34"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="DefaultClause" id="prod-DefaultClause">
-    <emu-nt><a href="#prod-DefaultClause">DefaultClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="6782073e">
+    <emu-nt><a href="#prod-DefaultClause">DefaultClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="z4ihpgum">
         <emu-t>default</emu-t>
         <emu-t>:</emu-t>
-        <emu-nt optional="" id="_ref_38"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_35"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If <emu-nt id="_ref_39"><a href="#prod-StatementList">StatementList</a></emu-nt> is not present, return <emu-val>false</emu-val>.</li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_40"><a href="#prod-StatementList">StatementList</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If <emu-nt id="_ref_36"><a href="#prod-StatementList">StatementList</a></emu-nt> is not present, return <emu-val>false</emu-val>.</li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_37"><a href="#prod-StatementList">StatementList</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="TryStatement" id="prod-TryStatement">
-    <emu-nt><a href="#prod-TryStatement">TryStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a8714e57">
+    <emu-nt><a href="#prod-TryStatement">TryStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qhfov2lc">
         <emu-t>try</emu-t>
-        <emu-nt id="_ref_41"><a href="#prod-Block">Block</a></emu-nt>
-        <emu-nt id="_ref_42"><a href="#prod-Catch">Catch</a></emu-nt>
+        <emu-nt id="_ref_38"><a href="#prod-Block">Block</a></emu-nt>
+        <emu-nt id="_ref_39"><a href="#prod-Catch">Catch</a></emu-nt>
     </emu-rhs>
-    <emu-rhs a="1b19737c">
+    <emu-rhs a="gxlzfd5s">
         <emu-t>try</emu-t>
-        <emu-nt id="_ref_43"><a href="#prod-Block">Block</a></emu-nt>
-        <emu-nt id="_ref_44"><a href="#prod-Catch">Catch</a></emu-nt>
+        <emu-nt id="_ref_40"><a href="#prod-Block">Block</a></emu-nt>
+        <emu-nt id="_ref_41"><a href="#prod-Catch">Catch</a></emu-nt>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-Finally">Finally</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If EndsInIterationOrDeclaration of <emu-nt id="_ref_45"><a href="#prod-Block">Block</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_46"><a href="#prod-Catch">Catch</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If EndsInIterationOrDeclaration of <emu-nt id="_ref_42"><a href="#prod-Block">Block</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_43"><a href="#prod-Catch">Catch</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="TryStatement">
-    <emu-nt><a href="#prod-TryStatement">TryStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="5ec68ab9">
+    <emu-nt><a href="#prod-TryStatement">TryStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xsakufa6">
         <emu-t>try</emu-t>
-        <emu-nt id="_ref_47"><a href="#prod-Block">Block</a></emu-nt>
+        <emu-nt id="_ref_44"><a href="#prod-Block">Block</a></emu-nt>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-Finally">Finally</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_48"><a href="#prod-Block">Block</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_45"><a href="#prod-Block">Block</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="Catch" id="prod-Catch">
-    <emu-nt><a href="#prod-Catch">Catch</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ddc13c36">
+    <emu-nt><a href="#prod-Catch">Catch</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="3ce8nhiw">
         <emu-t>catch</emu-t>
         <emu-t>(</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-CatchParameter">CatchParameter</a></emu-nt>
         <emu-t>)</emu-t>
-        <emu-nt id="_ref_49"><a href="#prod-Block">Block</a></emu-nt>
+        <emu-nt id="_ref_46"><a href="#prod-Block">Block</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_50"><a href="#prod-Block">Block</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Return EndsInIterationOrDeclaration of <emu-nt id="_ref_47"><a href="#prod-Block">Block</a></emu-nt> with arguments <var>labelSet</var> and <var>isLast</var>.</li></ol></emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-isempty">
     <h1><span class="secnum">1.4</span> Static Semantics: IsEmpty</h1>
     <p>With parameter <var>labelSet</var>.</p>
     <emu-note><span class="note">Note</span><div class="note-contents">
-      <p>Here "empty" means "consisting solely of <emu-nt><a href="https://tc39.es/ecma262/#prod-EmptyStatement">EmptyStatement</a></emu-nt>s, <emu-nt><a href="https://tc39.es/ecma262/#prod-DebuggerStatement">DebuggerStatement</a></emu-nt>s, <emu-nt id="_ref_51"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt>s which immediately unconditionally break themselves, or <emu-nt><a href="https://tc39.es/ecma262/#prod-BlockStatement">BlockStatement</a></emu-nt>s which are themselves empty".</p>
+      <p>Here "empty" means "consisting solely of <emu-nt><a href="https://tc39.es/ecma262/#prod-EmptyStatement">EmptyStatement</a></emu-nt>s, <emu-nt><a href="https://tc39.es/ecma262/#prod-DebuggerStatement">DebuggerStatement</a></emu-nt>s, <emu-nt id="_ref_48"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt>s which immediately unconditionally break themselves, or <emu-nt><a href="https://tc39.es/ecma262/#prod-BlockStatement">BlockStatement</a></emu-nt>s which are themselves empty".</p>
       <p><var>labelSet</var> is always empty when this SDO is invoked by other operations. It is used to track internally the labels which, if broken, would cause the statements being examined to be empty, as in <code>label: { break label; }</code>.</p>
     </div></emu-note>
     <emu-grammar><emu-production name="StatementList">
-    <emu-nt><a href="#prod-StatementList">StatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="0db4597a">
-        <emu-nt id="_ref_52"><a href="#prod-StatementList">StatementList</a></emu-nt>
-        <emu-nt id="_ref_53"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt>
+    <emu-nt><a href="#prod-StatementList">StatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="dbrzeh7l">
+        <emu-nt id="_ref_49"><a href="#prod-StatementList">StatementList</a></emu-nt>
+        <emu-nt id="_ref_50"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If IsBreak of <emu-nt id="_ref_54"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If IsEmpty of <emu-nt id="_ref_55"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with argument <var>labelSet</var> is <emu-val>false</emu-val>, return <emu-val>false</emu-val>.</li><li>Return IsEmpty of <emu-nt id="_ref_56"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If IsBreak of <emu-nt id="_ref_51"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If IsEmpty of <emu-nt id="_ref_52"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with argument <var>labelSet</var> is <emu-val>false</emu-val>, return <emu-val>false</emu-val>.</li><li>Return IsEmpty of <emu-nt id="_ref_53"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="Statement">
-    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="7338aabb"><emu-nt><a href="https://tc39.es/ecma262/#prod-EmptyStatement">EmptyStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="21212edb"><emu-nt><a href="https://tc39.es/ecma262/#prod-DebuggerStatement">DebuggerStatement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="cziqu-45"><emu-nt><a href="https://tc39.es/ecma262/#prod-EmptyStatement">EmptyStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="iseu28qi"><emu-nt><a href="https://tc39.es/ecma262/#prod-DebuggerStatement">DebuggerStatement</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="Block">
-    <emu-nt><a href="#prod-Block">Block</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="81ba5a4a">
+    <emu-nt><a href="#prod-Block">Block</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gbpaspne">
         <emu-t>{</emu-t>
         <emu-t>}</emu-t>
     </emu-rhs>
@@ -2100,43 +2094,43 @@ li.menu-search-result-term:before {
 </emu-grammar>
     <emu-alg><ol><li>Return <emu-val>true</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="StatementListItem">
-    <emu-nt><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="d6f37721"><emu-nt><a href="https://tc39.es/ecma262/#prod-Declaration">Declaration</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="1vn3ibwe"><emu-nt><a href="https://tc39.es/ecma262/#prod-Declaration">Declaration</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="Statement">
-    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="8b0c0df0"><emu-nt><a href="https://tc39.es/ecma262/#prod-VariableStatement">VariableStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="82c424b7"><emu-nt id="_ref_57"><a href="#prod-ExpressionStatement">ExpressionStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="b2403005"><emu-nt id="_ref_58"><a href="#prod-IfStatement">IfStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="09d6185a"><emu-nt id="_ref_59"><a href="#prod-BreakableStatement">BreakableStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="1d7d329e"><emu-nt id="_ref_60"><a href="#prod-ContinueStatement">ContinueStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="aa6f7913"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="c9eeb058"><emu-nt id="_ref_61"><a href="#prod-WithStatement">WithStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="867b4090"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ThrowStatement">ThrowStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="7b1fdcae"><emu-nt id="_ref_62"><a href="#prod-TryStatement">TryStatement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwwn8atx"><emu-nt><a href="https://tc39.es/ecma262/#prod-VariableStatement">VariableStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="gsqkt2bv"><emu-nt id="_ref_54"><a href="#prod-ExpressionStatement">ExpressionStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="skawbrez"><emu-nt id="_ref_55"><a href="#prod-IfStatement">IfStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="cdyywqxx"><emu-nt id="_ref_56"><a href="#prod-BreakableStatement">BreakableStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="hx0ynljx"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ContinueStatement">ContinueStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="qm95e4wi"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="ye6wwgts"><emu-nt id="_ref_57"><a href="#prod-WithStatement">WithStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="hntake-o"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ThrowStatement">ThrowStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="ex_crokj"><emu-nt id="_ref_58"><a href="#prod-TryStatement">TryStatement</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="LabelledItem">
-    <emu-nt><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fa7a943c"><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="-nqupnlb"><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar>
     <emu-alg><ol><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="CaseClause">
-    <emu-nt><a href="#prod-CaseClause">CaseClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="c76d0d30">
+    <emu-nt><a href="#prod-CaseClause">CaseClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="x20nmjyd">
         <emu-t>case</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt>
         <emu-t>:</emu-t>
-        <emu-nt optional="" id="_ref_63"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_59"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="DefaultClause">
-    <emu-nt><a href="#prod-DefaultClause">DefaultClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="6782073e">
+    <emu-nt><a href="#prod-DefaultClause">DefaultClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="z4ihpgum">
         <emu-t>default</emu-t>
         <emu-t>:</emu-t>
-        <emu-nt optional="" id="_ref_64"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_60"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If <emu-nt id="_ref_65"><a href="#prod-StatementList">StatementList</a></emu-nt> is not present, return <emu-val>true</emu-val>.</li><li>Return IsEmpty of <emu-nt id="_ref_66"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If <emu-nt id="_ref_61"><a href="#prod-StatementList">StatementList</a></emu-nt> is not present, return <emu-val>true</emu-val>.</li><li>Return IsEmpty of <emu-nt id="_ref_62"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="BreakStatement" id="prod-BreakStatement">
-    <emu-nt><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="b65229e7">
+    <emu-nt><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="tlip5zkt">
         <emu-t>break</emu-t>
         <emu-t>;</emu-t>
     </emu-rhs>
@@ -2144,7 +2138,7 @@ li.menu-search-result-term:before {
 </emu-grammar>
     <emu-alg><ol><li>If <emu-const>empty</emu-const> is an element of <var>labelSet</var>, return <emu-val>true</emu-val>.</li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="BreakStatement">
-    <emu-nt><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="91c83ecb">
+    <emu-nt><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="kcg-yy3r">
         <emu-t>break</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>
         <emu-t>;</emu-t>
@@ -2153,52 +2147,52 @@ li.menu-search-result-term:before {
 </emu-grammar>
     <emu-alg><ol><li>Let <var>label</var> be the StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>.</li><li>If <var>label</var> is an element of <var>labelSet</var>, return <emu-val>true</emu-val>.</li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="LabelledStatement">
-    <emu-nt><a href="#prod-LabelledStatement">LabelledStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="51b6efb5">
+    <emu-nt><a href="#prod-LabelledStatement">LabelledStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ubbvtbun">
         <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_67"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt>
+        <emu-nt id="_ref_63"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>Let <var>label</var> be the StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>.</li><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with <var>label</var> appended.</li><li>Return IsEmpty of <emu-nt id="_ref_68"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> with argument <var>newLabelSet</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Let <var>label</var> be the StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>.</li><li>Let <var>newLabelSet</var> be a copy of <var>labelSet</var> with <var>label</var> appended.</li><li>Return IsEmpty of <emu-nt id="_ref_64"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> with argument <var>newLabelSet</var>.</li></ol></emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-isbreak">
     <h1><span class="secnum">1.5</span> Static Semantics: IsBreak</h1>
     <p>With parameter <var>labelSet</var>.</p>
     <emu-note><span class="note">Note</span><div class="note-contents">
-      <p>This SDO answers the question "is the first non-empty statement in this <emu-xref href="#sec-syntactic-grammar"><a href="https://tc39.es/ecma262/#sec-syntactic-grammar">Parse Node</a></emu-xref> a <emu-nt id="_ref_69"><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> for one of the labels in <var>labelSet</var>?". It will recurse into <emu-nt><a href="https://tc39.es/ecma262/#prod-BlockStatement">BlockStatement</a></emu-nt>s but not other kinds of statement-containing statements.</p>
+      <p>This SDO answers the question "is the first non-empty statement in this <emu-xref href="#sec-syntactic-grammar"><a href="https://tc39.es/ecma262/#sec-syntactic-grammar">Parse Node</a></emu-xref> a <emu-nt id="_ref_65"><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> for one of the labels in <var>labelSet</var>?". It will recurse into <emu-nt><a href="https://tc39.es/ecma262/#prod-BlockStatement">BlockStatement</a></emu-nt>s but not other kinds of statement-containing statements.</p>
     </div></emu-note>
     <emu-grammar><emu-production name="StatementList">
-    <emu-nt><a href="#prod-StatementList">StatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="0db4597a">
-        <emu-nt id="_ref_70"><a href="#prod-StatementList">StatementList</a></emu-nt>
-        <emu-nt id="_ref_71"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt>
+    <emu-nt><a href="#prod-StatementList">StatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="dbrzeh7l">
+        <emu-nt id="_ref_66"><a href="#prod-StatementList">StatementList</a></emu-nt>
+        <emu-nt id="_ref_67"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If IsBreak of <emu-nt id="_ref_72"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If IsEmpty of <emu-nt id="_ref_73"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument « » is <emu-val>false</emu-val>, return <emu-val>false</emu-val>.</li><li>Return IsBreak of <emu-nt id="_ref_74"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If IsBreak of <emu-nt id="_ref_68"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var> is <emu-val>true</emu-val>, return <emu-val>true</emu-val>.</li><li>If IsEmpty of <emu-nt id="_ref_69"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument « » is <emu-val>false</emu-val>, return <emu-val>false</emu-val>.</li><li>Return IsBreak of <emu-nt id="_ref_70"><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="StatementListItem">
-    <emu-nt><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="d6f37721"><emu-nt><a href="https://tc39.es/ecma262/#prod-Declaration">Declaration</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-StatementListItem">StatementListItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="1vn3ibwe"><emu-nt><a href="https://tc39.es/ecma262/#prod-Declaration">Declaration</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="Statement">
-    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="8b0c0df0"><emu-nt><a href="https://tc39.es/ecma262/#prod-VariableStatement">VariableStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="7338aabb"><emu-nt><a href="https://tc39.es/ecma262/#prod-EmptyStatement">EmptyStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="82c424b7"><emu-nt id="_ref_75"><a href="#prod-ExpressionStatement">ExpressionStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="b2403005"><emu-nt id="_ref_76"><a href="#prod-IfStatement">IfStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="09d6185a"><emu-nt id="_ref_77"><a href="#prod-BreakableStatement">BreakableStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="1d7d329e"><emu-nt id="_ref_78"><a href="#prod-ContinueStatement">ContinueStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="aa6f7913"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="c9eeb058"><emu-nt id="_ref_79"><a href="#prod-WithStatement">WithStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="08827f68"><emu-nt id="_ref_80"><a href="#prod-LabelledStatement">LabelledStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="867b4090"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ThrowStatement">ThrowStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="7b1fdcae"><emu-nt id="_ref_81"><a href="#prod-TryStatement">TryStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="21212edb"><emu-nt><a href="https://tc39.es/ecma262/#prod-DebuggerStatement">DebuggerStatement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwwn8atx"><emu-nt><a href="https://tc39.es/ecma262/#prod-VariableStatement">VariableStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="cziqu-45"><emu-nt><a href="https://tc39.es/ecma262/#prod-EmptyStatement">EmptyStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="gsqkt2bv"><emu-nt id="_ref_71"><a href="#prod-ExpressionStatement">ExpressionStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="skawbrez"><emu-nt id="_ref_72"><a href="#prod-IfStatement">IfStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="cdyywqxx"><emu-nt id="_ref_73"><a href="#prod-BreakableStatement">BreakableStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="hx0ynljx"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ContinueStatement">ContinueStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="qm95e4wi"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ReturnStatement">ReturnStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="ye6wwgts"><emu-nt id="_ref_74"><a href="#prod-WithStatement">WithStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="cij_anje"><emu-nt id="_ref_75"><a href="#prod-LabelledStatement">LabelledStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="hntake-o"><emu-nt><a href="https://tc39.es/ecma262/#prod-asi-rules-ThrowStatement">ThrowStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="ex_crokj"><emu-nt id="_ref_76"><a href="#prod-TryStatement">TryStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="iseu28qi"><emu-nt><a href="https://tc39.es/ecma262/#prod-DebuggerStatement">DebuggerStatement</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="LabelledItem">
-    <emu-nt><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fa7a943c"><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="-nqupnlb"><emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="Block">
-    <emu-nt><a href="#prod-Block">Block</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="81ba5a4a">
+    <emu-nt><a href="#prod-Block">Block</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gbpaspne">
         <emu-t>{</emu-t>
         <emu-t>}</emu-t>
     </emu-rhs>
@@ -2206,24 +2200,24 @@ li.menu-search-result-term:before {
 </emu-grammar>
     <emu-alg><ol><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="CaseClause">
-    <emu-nt><a href="#prod-CaseClause">CaseClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="c76d0d30">
+    <emu-nt><a href="#prod-CaseClause">CaseClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="x20nmjyd">
         <emu-t>case</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-Expression">Expression</a></emu-nt>
         <emu-t>:</emu-t>
-        <emu-nt optional="" id="_ref_82"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_77"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="DefaultClause">
-    <emu-nt><a href="#prod-DefaultClause">DefaultClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="6782073e">
+    <emu-nt><a href="#prod-DefaultClause">DefaultClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="z4ihpgum">
         <emu-t>default</emu-t>
         <emu-t>:</emu-t>
-        <emu-nt optional="" id="_ref_83"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_78"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>If <emu-nt id="_ref_84"><a href="#prod-StatementList">StatementList</a></emu-nt> is not present, return <emu-val>false</emu-val>.</li><li>Return IsBreak of <emu-nt id="_ref_85"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>If <emu-nt id="_ref_79"><a href="#prod-StatementList">StatementList</a></emu-nt> is not present, return <emu-val>false</emu-val>.</li><li>Return IsBreak of <emu-nt id="_ref_80"><a href="#prod-StatementList">StatementList</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="BreakStatement">
-    <emu-nt><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="b65229e7">
+    <emu-nt><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="tlip5zkt">
         <emu-t>break</emu-t>
         <emu-t>;</emu-t>
     </emu-rhs>
@@ -2231,7 +2225,7 @@ li.menu-search-result-term:before {
 </emu-grammar>
     <emu-alg><ol><li>If <emu-const>empty</emu-const> is an element of <var>labelSet</var>, return <emu-val>true</emu-val>.</li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="BreakStatement">
-    <emu-nt><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="91c83ecb">
+    <emu-nt><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="kcg-yy3r">
         <emu-t>break</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>
         <emu-t>;</emu-t>
@@ -2240,14 +2234,14 @@ li.menu-search-result-term:before {
 </emu-grammar>
     <emu-alg><ol><li>Let <var>label</var> be the StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>.</li><li>If <var>label</var> is an element of <var>labelSet</var>, return <emu-val>true</emu-val>.</li><li>Return <emu-val>false</emu-val>.</li></ol></emu-alg>
     <emu-grammar><emu-production name="LabelledStatement">
-    <emu-nt><a href="#prod-LabelledStatement">LabelledStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="51b6efb5">
+    <emu-nt><a href="#prod-LabelledStatement">LabelledStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ubbvtbun">
         <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_86"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt>
+        <emu-nt id="_ref_81"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-    <emu-alg><ol><li>Return IsBreak of <emu-nt id="_ref_87"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Return IsBreak of <emu-nt id="_ref_82"><a href="#prod-LabelledItem">LabelledItem</a></emu-nt> with argument <var>labelSet</var>.</li></ol></emu-alg>
   </emu-clause>
 </emu-clause>
 
@@ -2255,11 +2249,11 @@ li.menu-search-result-term:before {
   <h1><span class="secnum">2</span> Integration</h1>
   <h2>Syntax</h2>
   <emu-grammar><emu-production name="PrimaryExpression" params="Yield, Await" id="prod-PrimaryExpression">
-    <emu-nt params="Yield, Await"><a href="#prod-PrimaryExpression">PrimaryExpression</a><emu-mods><emu-params>[Yield, Await]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <ins><emu-rhs a="4df04a53"><emu-nt params="?Yield, ?Await" id="_ref_88"><a href="#prod-DoExpression">DoExpression</a><emu-mods><emu-params>[?Yield, ?Await]</emu-params></emu-mods></emu-nt></emu-rhs>
+    <emu-nt params="Yield, Await"><a href="#prod-PrimaryExpression">PrimaryExpression</a><emu-mods><emu-params>[Yield, Await]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <ins><emu-rhs a="tfbku6cq"><emu-nt params="?Yield, ?Await" id="_ref_83"><a href="#prod-DoExpression">DoExpression</a><emu-mods><emu-params>[?Yield, ?Await]</emu-params></emu-mods></emu-nt></emu-rhs>
     </ins>
 </emu-production>
 <emu-production name="ExpressionStatement" params="Yield, Await" id="prod-ExpressionStatement">
-    <emu-nt params="Yield, Await"><a href="#prod-ExpressionStatement">ExpressionStatement</a><emu-mods><emu-params>[Yield, Await]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="421c75a2">
+    <emu-nt params="Yield, Await"><a href="#prod-ExpressionStatement">ExpressionStatement</a><emu-mods><emu-params>[Yield, Await]</emu-params></emu-mods></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qhx1otia">
         <emu-gann>[lookahead ∉ { <emu-t>{</emu-t>, <emu-t>function</emu-t>, <emu-t>async</emu-t>
         <emu-gann>[no <emu-nt><a href="https://tc39.es/ecma262/#prod-LineTerminator">LineTerminator</a></emu-nt> here]</emu-gann>
         <emu-t>function</emu-t>, <emu-t>class</emu-t>, <emu-t>let</emu-t>
@@ -2271,50 +2265,12 @@ li.menu-search-result-term:before {
 </emu-grammar>
   <emu-note><span class="note">Note</span><div class="note-contents"><p>Note the additional lookahead for <code>do</code> in ExpressionStatements. This prevents using <code>do</code> expressions in statement position, where they are ambiguous with <code>do</code> statements.</p></div></emu-note>
   <h2>Semantics</h2>
-  <p>TODO: thread VarDeclaredNames through the entire expression grammar and update existing uses (<emu-nt id="_ref_89"><a href="#prod-IfStatement">IfStatement</a></emu-nt> etc) to use it.</p>
-  <p>TODO: probably thread ContainsDuplicateLabels through the entire expression grammar.</p>
+  <p>TODO: thread the Return grammar parameter through the entire expression grammar. It is allowed in parameter lists and arrow expression bodies, but not class bodies. In other circumstances it's inherited from the containing statement.</p>
+  <p>TODO: thread ContainsUndefinedBreakTarget and ContainsUndefinedContinueTarget through the entire expression grammar.</p>
+  <p>TODO: thread VarDeclaredNames through the entire expression grammar and update existing uses (<emu-nt id="_ref_84"><a href="#prod-IfStatement">IfStatement</a></emu-nt> etc) to use it.</p>
+  <p>TODO: thread ContainsDuplicateLabels through the entire expression grammar.</p>
   <p>TODO: ban do-exprs which are inside of formal parameter lists and which Contain a <emu-nt><a href="https://tc39.es/ecma262/#prod-VariableStatement">VariableStatement</a></emu-nt>. Probably needs a new SDO, sigh. (Or, reconsider banning this, I guess.)</p>
   <p>Maybe it is worth abstracting out a single "CollectDoExpressionsFromExpression" SDO that other things can be written in terms of.</p>
-
-  <h2>Early Errors</h2>
-  <emu-clause id="sec-ins-continue-statement-static-semantics-early-errors">
-  <h1><span class="secnum">2.1</span> Static Semantics: Early Errors</h1>
-  <emu-grammar><emu-production name="ContinueStatement" id="prod-ContinueStatement">
-    <emu-nt><a href="#prod-ContinueStatement">ContinueStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="e903cf81">
-        <emu-t>continue</emu-t>
-        <emu-t>;</emu-t>
-    </emu-rhs>
-    <emu-rhs a="5a1eea0d">
-        <emu-t>continue</emu-t>
-        <emu-nt><a href="https://tc39.es/ecma262/#prod-LabelIdentifier">LabelIdentifier</a></emu-nt>
-        <emu-t>;</emu-t>
-    </emu-rhs>
-</emu-production>
-</emu-grammar>
-  <ul>
-    <li>
-      It is a Syntax Error if this <emu-nt id="_ref_90"><a href="#prod-ContinueStatement">ContinueStatement</a></emu-nt> is not nested, directly or indirectly (but not crossing function <ins>or <code>do</code>-expression</ins> boundaries), within an <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-IterationStatement">IterationStatement</a></emu-nt>.
-    </li>
-  </ul>
-  <emu-clause id="sec-ins-break-statement-static-semantics-early-errors">
-    <h1><span class="secnum">2.1.1</span> Static Semantics: Early Errors</h1>
-    <emu-grammar><emu-production name="BreakStatement" collapsed="">
-    <emu-nt><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="b65229e7">
-        <emu-t>break</emu-t>
-        <emu-t>;</emu-t>
-    </emu-rhs>
-</emu-production>
-</emu-grammar>
-    <ul>
-      <li>
-        It is a Syntax Error if this <emu-nt id="_ref_91"><a href="#prod-BreakStatement">BreakStatement</a></emu-nt> is not nested, directly or indirectly (but not crossing function <ins>or <code>do</code>-expression</ins> boundaries), within an <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-IterationStatement">IterationStatement</a></emu-nt> or a <emu-nt id="_ref_92"><a href="#prod-SwitchStatement">SwitchStatement</a></emu-nt>.
-      </li>
-    </ul>
-  </emu-clause>
-
-
-</emu-clause>
-
 </emu-clause><emu-annex id="sec-copyright-and-software-license">
       <h1><span class="secnum">A</span> Copyright &amp; Software License</h1>
       
@@ -2334,4 +2290,6 @@ li.menu-search-result-term:before {
 
 <p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
-    </emu-annex></div></body>
+    </emu-annex>
+
+</div></body>

--- a/spec.emu
+++ b/spec.emu
@@ -15,8 +15,8 @@ contributors: Dave Herman, Chris Krychom, Kevin Gibbons
   <h1>Do Expressions</h1>
   <h2>Syntax</h2>
   <emu-grammar type="definition">
-    DoExpression[Yield, Await] :
-      `do` Block[?Yield, ?Await, ~Return]
+    DoExpression[Yield, Await, Return] :
+      `do` Block[?Yield, ?Await, ?Return]
   </emu-grammar>
 
   <emu-clause id="sec-doexpression-runtime-semantics-evaluation">
@@ -33,18 +33,12 @@ contributors: Dave Herman, Chris Krychom, Kevin Gibbons
     <emu-grammar>DoExpression: `do` Block</emu-grammar>
     <ul>
       <li>
-        It is a Syntax Error if ContainsUndefinedBreakTarget of |Block| with argument &laquo; &raquo; is *true*.
-      </li>
-      <li>
-        It is a Syntax Error if ContainsUndefinedContinueTarget of |Block| with arguments &laquo; &raquo; and &laquo; &raquo; is *true*.
+        TODO: a syntax error for this is contained in a loop head and contains a break or continue which would break or continue the loop.
       </li>
       <li>
         It is a Syntax Error if EndsInIterationOrDeclaration of |Block| with arguments &laquo; &raquo; and *true* is *true*.
       </li>
     </ul>
-    <emu-note type="editor">
-      <p>The first two Syntax Errors are present for all statement lists which are not immediately contained in other statement lists, i.e. for function bodies, scripts, modules, and now do expressions.</p>
-    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-endsiniterationordeclaration">
@@ -390,35 +384,12 @@ contributors: Dave Herman, Chris Krychom, Kevin Gibbons
   </emu-grammar>
   <emu-note><p>Note the additional lookahead for `do` in ExpressionStatements. This prevents using `do` expressions in statement position, where they are ambiguous with `do` statements.</p></emu-note>
   <h2>Semantics</h2>
+  <p>TODO: thread the Return grammar parameter through the entire expression grammar. It is allowed in parameter lists and arrow expression bodies, but not class bodies. In other circumstances it's inherited from the containing statement.</p>
+  <p>TODO: thread ContainsUndefinedBreakTarget and ContainsUndefinedContinueTarget through the entire expression grammar.</p>
   <p>TODO: thread VarDeclaredNames through the entire expression grammar and update existing uses (|IfStatement| etc) to use it.</p>
-  <p>TODO: probably thread ContainsDuplicateLabels through the entire expression grammar.</p>
+  <p>TODO: thread ContainsDuplicateLabels through the entire expression grammar.</p>
   <p>TODO: ban do-exprs which are inside of formal parameter lists and which Contain a |VariableStatement|. Probably needs a new SDO, sigh. (Or, reconsider banning this, I guess.)</p>
   <p>Maybe it is worth abstracting out a single "CollectDoExpressionsFromExpression" SDO that other things can be written in terms of.</p>
-
-  <h2>Early Errors</h2>
-  <emu-clause id="sec-ins-continue-statement-static-semantics-early-errors">
-  <h1>Static Semantics: Early Errors</h1>
-  <emu-grammar>
-    ContinueStatement :
-      `continue` `;`
-      `continue` LabelIdentifier `;`
-  </emu-grammar>
-  <ul>
-    <li>
-      It is a Syntax Error if this |ContinueStatement| is not nested, directly or indirectly (but not crossing function <ins>or `do`-expression</ins> boundaries), within an |IterationStatement|.
-    </li>
-  </ul>
-  <emu-clause id="sec-ins-break-statement-static-semantics-early-errors">
-    <h1>Static Semantics: Early Errors</h1>
-    <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
-    <ul>
-      <li>
-        It is a Syntax Error if this |BreakStatement| is not nested, directly or indirectly (but not crossing function <ins>or `do`-expression</ins> boundaries), within an |IterationStatement| or a |SwitchStatement|.
-      </li>
-    </ul>
-  </emu-clause>
-
-
 </emu-clause>
 
 </emu-clause>


### PR DESCRIPTION
This switches to allowing `return`, etc, to cross the boundary of the `do`. I'm landing this now, but we can continue discussing it.

See also https://github.com/tc39/proposal-do-expressions/issues/30.